### PR TITLE
DEVDOCS-5628: [revise] remove remote_api_scripts

### DIFF
--- a/models/theme_objects/_all.yml
+++ b/models/theme_objects/_all.yml
@@ -181,11 +181,6 @@ properties:
     allOf:
       -$ref: ./products.yml
     type: object
-  remote_api_scripts:
-    description: 
-    allOf:
-      -$ref: ./remote_api_scripts.yml
-    type: object
   settings:
     description: 
     allOf:


### PR DESCRIPTION
# [DEVDOCS-5628]
{Ticket number or summary of work}

## What changed?
Removed remote_api_scripts because it has been removed from stencil.

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}


[DEVDOCS-5628]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ